### PR TITLE
add link to GitHub in attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             minZoom:1
         }).fitBounds([[36.339226,22.305707],[36.733143,22.573498]]);
         var hash = new L.Hash(map);
-        map.attributionControl.setPrefix('<a href="https://github.com/tomchadwin/qgis2web" target="_blank">qgis2web</a> &middot; <a href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> &middot; <a href="https://qgis.org">QGIS</a>');
+        map.attributionControl.setPrefix('<a href="https://github.com/rmseifried/leigh-fermors" target="_blank">View this map in GitHub</a> &VerticalLine; <a href="https://github.com/tomchadwin/qgis2web" target="_blank">qgis2web</a> &middot; <a href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> &middot; <a href="https://qgis.org">QGIS</a>');
         var autolinker = new Autolinker({truncate: {length: 30, location: 'smart'}});
         var bounds_group = new L.featureGroup([]);
         function setBounds() {


### PR DESCRIPTION
## Description

Adds a link to the GitHub repo in the attribution. The GitHub link currently exists in the abstract, but the code does not currently support touch events in mobile devices and therefore there is no way for a mobile device user to view this link.

Related to issue #6 

<img width="489" alt="Screen Shot 2023-01-11 at 11 53 40 AM" src="https://user-images.githubusercontent.com/36506059/211867806-6d9d0049-5c7a-4fc5-b2a1-3ccbbc65ca12.png">
